### PR TITLE
Increase max width of LayoutGrid component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qs-ui-lib",
-  "version": "0.0.53-development",
+  "version": "0.0.54-development",
   "description": "Quantstamp's Canonical UI Library",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/components/LayoutGrid/LayoutGrid.js
+++ b/src/components/LayoutGrid/LayoutGrid.js
@@ -11,7 +11,7 @@ const LayoutGrid = ({ className, children, offset }) => (
     <style jsx>{`
       .LayoutGrid {
         margin: auto;
-        max-width: ${LayoutSizes[3]};
+        max-width: ${LayoutSizes[5]};
         display: flex;
         justify-content: space-between;
         width: 100%;


### PR DESCRIPTION
This is a tiny PR for making LayoutGrid width 1440px to match Jackson's latest design. Updates version to 0.0.54.