### PR TITLE
Update CodeInputArea value when code prop changes

### DIFF
--- a/src/components/CodeInputArea/CodeInputArea.js
+++ b/src/components/CodeInputArea/CodeInputArea.js
@@ -63,6 +63,15 @@ class CodeInputArea extends Component {
     looper(cm);
   };
 
+  componentDidUpdate(oldProps) {
+    if (
+      oldProps.code !== this.props.code &&
+      this.props.code !== this.state.value
+    ) {
+      this.setState({ value: this.props.code });
+    }
+  }
+
   render() {
     return (
       <div


### PR DESCRIPTION
The current CodeInputArea component only loads the value from the `code` property into the editor when the component is constructed.

This update will update the editor if the `code` prop is changed.